### PR TITLE
パフォーマンスの改善

### DIFF
--- a/Misq/Core.cs
+++ b/Misq/Core.cs
@@ -1,8 +1,9 @@
-﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace Misq
 {

--- a/Misq/Core.cs
+++ b/Misq/Core.cs
@@ -8,6 +8,7 @@ namespace Misq
 {
 	public static class Core
 	{
+		static Lazy<HttpClient> _client = new Lazy<HttpClient>();
 		/// <summary>
 		/// APIにリクエストします。
 		/// </summary>
@@ -17,7 +18,7 @@ namespace Misq
 		/// <returns>レスポンス</returns>
 		public static async Task<dynamic> Request(string host, string endpoint, Dictionary<string, object> ps)
 		{
-			var client = new HttpClient();
+			var client = _client.Value;
 
 			var ep = $"{host}/api/{endpoint}";
 
@@ -41,7 +42,7 @@ namespace Misq
 		/// <returns>レスポンス</returns>
 		public static async Task<dynamic> RequestWithBinary(string host, string endpoint, MultipartFormDataContent ps)
 		{
-			var client = new HttpClient();
+			var client = _client.Value;
 
 			var ep = $"{host}/api/{endpoint}";
 


### PR DESCRIPTION
HttpClientはインスタンス生成コストが非常に高いので、メソッド毎にインスタンスを生成することでパフォーマンスに悪影響を及ぼしていると考えられる。